### PR TITLE
Add Blazor support and 2k8 Combo Generator

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,104 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch for the app's folder path
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get latest .NET SDK
+        uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
+        with:
+          dotnet-version: '9.0'
+
+      - name: Publish app
+        run: dotnet publish blazor/PoprunsBlazorPages -c Release -o blazor/publish
+
+      - name: Remove published index.html
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: blazor/publish/wwwroot/index.html
+
+      - name: Compress _framework to zip archive
+        uses: vimtor/action-zip@v1.2
+        with:
+          files: blazor/publish/wwwroot/_framework
+          dest: _framework.zip
+
+      - name: Extract _framework in root directory
+        uses: ihiroky/extract-action@v1
+        with:
+          file_path: _framework.zip
+          extract_dir: _framework
+
+      - name: Remove _framework.zip archive
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: _framework.zip
+
+      - name: Remove _framework from publish directory
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: blazor/publish/wwwroot/_framework
+
+      - name: Compress wwwroot to zip archive
+        uses: vimtor/action-zip@v1.2
+        with:
+          files: blazor/publish/wwwroot
+          dest: __blazor/wwwroot.zip
+
+      - name: Extract wwwroot in __blazor directory
+        uses: ihiroky/extract-action@v1
+        with:
+          file_path: __blazor/wwwroot.zip
+          extract_dir: __blazor/wwwroot
+
+      - name: Remove wwwroot.zip archive
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: __blazor/wwwroot.zip
+
+      - name: Remove blazor source folder
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: blazor
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/404.html
+++ b/404.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PoPRuns - Prince of Persia Speedruns</title>
+    <base href="/"/>
+    <link rel="stylesheet" href="__blazor/css/app.css" />
+    <link rel="stylesheet" href="__blazor/PoprunsBlazorPages.styles.css" />
+</head>
+
+<body>
+    <div id="app"></div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/blazor/.gitattributes
+++ b/blazor/.gitattributes
@@ -1,0 +1,1 @@
+*.js binary

--- a/blazor/.gitignore
+++ b/blazor/.gitignore
@@ -1,0 +1,6 @@
+.vs
+bin
+obj
+PublishProfiles
+
+*.user

--- a/blazor/PoprunsBlazorPages.Testing/ComboGeneratorTests.cs
+++ b/blazor/PoprunsBlazorPages.Testing/ComboGeneratorTests.cs
@@ -1,0 +1,117 @@
+using PoprunsBlazorPages.Pop2008.ComboGenerator;
+using System;
+using static PoprunsBlazorPages.Pop2008.ComboGenerator.Generator;
+
+namespace PoprunsBlazorPages.Testing;
+
+public static class ComboGeneratorTests
+{
+    private static readonly Enemy[] _allEnemies = [Enemy.Hunter, Enemy.Concubine, Enemy.Alchemist, Enemy.Dad];
+    private static readonly Enemy[] _allBasicEnemies = [Enemy.Hunter, Enemy.Concubine];
+    private static readonly Enemy[] _allNonBasicEnemies = [Enemy.Alchemist, Enemy.Dad];
+
+    [Fact]
+    public static void GetCombos_TooSmall_ThrowsException()
+    {
+        int hpMin = -10;
+        int hpMax = 12;
+
+        for (int i = hpMin; i <= hpMax; i++)
+        {
+            foreach (Enemy enemy in _allEnemies)
+            {
+                void GetCombos1() => GetCombos(i, enemy, false);
+                void GetCombos2() => GetCombos(i, enemy, true);
+
+                Assert.ThrowsAny<Exception>(GetCombos1);
+                Assert.ThrowsAny<Exception>(GetCombos2);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(13, 20, "B1")]
+    [InlineData(21, 26, "B2")]
+    public static void GetCombos_SmallValuesTest(int hpMin, int hpMax, string expectedCombos)
+    {
+        for (int i = hpMin; i <= hpMax; i++)
+        {
+            foreach (Enemy enemy in _allEnemies)
+            {
+                string combos1 = GetCombos(i, enemy, false);
+                string combos2 = GetCombos(i, enemy, true);
+
+                Assert.Equal(expectedCombos, combos1);
+                Assert.Equal(expectedCombos, combos2);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(27, 32, "B0 B1", "B1 B0")]
+    [InlineData(33, 38, "B0 B2", "B2 B0")]
+    [InlineData(39, 40, "B1^2", "B1^2")]
+    [InlineData(41, 46, "B1 B2", "B1 B2")]
+    [InlineData(47, 52, "B2^2", "B2^2")]
+    [InlineData(53, 58, "B0 B1 B2", "B1 B0 B2")]
+    [InlineData(59, 64, "B0 B2^2", "B2 B0 B2")]
+    [InlineData(65, 66, "B1^2 B2", "B1^2 B2")]
+    [InlineData(67, 72, "B1 B2^2", "B1 B2^2")]
+    [InlineData(73, 78, "B2^3", "B2^3")]
+    [InlineData(79, 84, "B0 B1 B2^2", "B1 B0 B2^2")]
+    [InlineData(85, 90, "B0 B2^3", "B2 B0 B2^2")]
+    [InlineData(91, 92, "B1^2 B2^2", "B1^2 B2^2")]
+    [InlineData(93, 98, "B1 B2^3", "B1 B2^3")]
+    [InlineData(99, 104, "B2^4", "B2^4")]
+    public static void GetCombos_BasicValuesTest(int hpMin, int hpMax, string expectedCombosB0Start, string expectedCombosNoB0Start)
+    {
+        for (int i = hpMin; i <= hpMax; i++)
+        {
+            foreach (Enemy enemy in _allBasicEnemies)
+            {
+                string combosB0Start = GetCombos(i, enemy, true);
+                string combosNoB0Start = GetCombos(i, enemy, false);
+
+                Assert.Equal(expectedCombosB0Start, combosB0Start);
+                Assert.Equal(expectedCombosNoB0Start, combosNoB0Start);
+            }
+            foreach (Enemy enemy in _allNonBasicEnemies)
+            {
+                string combosB0Start = GetCombos(i, enemy, true);
+
+                Assert.Equal(expectedCombosB0Start, combosB0Start);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(27, 32, "A1**")]
+    [InlineData(33, 34, "B2*")]
+    [InlineData(35, 40, "B1^2")]
+    [InlineData(41, 46, "B1 B2")]
+    [InlineData(47, 52, "B2^2")]
+    [InlineData(53, 54, "B1 B2*")]
+    [InlineData(55, 58, "B2 A1**")]
+    [InlineData(59, 60, "B2 B2*")]
+    [InlineData(61, 66, "B1^2 B2")]
+    [InlineData(67, 72, "B1 B2^2")]
+    [InlineData(73, 78, "B2^3")]
+    [InlineData(79, 80, "B1 B2 B2*")]
+    [InlineData(81, 84, "B2^2 A1**")]
+    [InlineData(85, 86, "B2^2 B2*")]
+    [InlineData(87, 92, "B1^2 B2^2")]
+    [InlineData(93, 98, "B1 B2^3")]
+    [InlineData(99, 104, "B2^4")]
+    public static void GetCombos_NonBasicValuesTest(int hpMin, int hpMax, string expectedCombos)
+    {
+        for (int i = hpMin; i <= hpMax; i++)
+        {
+            foreach (Enemy enemy in _allNonBasicEnemies)
+            {
+                string combos = GetCombos(i, enemy, false);
+
+                Assert.Equal(expectedCombos, combos);
+            }
+        }
+    }
+}

--- a/blazor/PoprunsBlazorPages.Testing/PoprunsBlazorPages.Testing.csproj
+++ b/blazor/PoprunsBlazorPages.Testing/PoprunsBlazorPages.Testing.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PoprunsBlazorPages.Testing</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageReference Include="xunit.v3" Version="3.0.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PoprunsBlazorPages\PoprunsBlazorPages.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/blazor/PoprunsBlazorPages.Testing/xunit.runner.json
+++ b/blazor/PoprunsBlazorPages.Testing/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/blazor/PoprunsBlazorPages.sln
+++ b/blazor/PoprunsBlazorPages.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36408.4
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoprunsBlazorPages", "PoprunsBlazorPages\PoprunsBlazorPages.csproj", "{F28B4963-D684-43CF-89BE-11284A5A6A77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoprunsBlazorPages.Testing", "PoprunsBlazorPages.Testing\PoprunsBlazorPages.Testing.csproj", "{16E7C7A9-277F-4CCF-90F0-6F722E5F5945}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F28B4963-D684-43CF-89BE-11284A5A6A77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F28B4963-D684-43CF-89BE-11284A5A6A77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F28B4963-D684-43CF-89BE-11284A5A6A77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F28B4963-D684-43CF-89BE-11284A5A6A77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16E7C7A9-277F-4CCF-90F0-6F722E5F5945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16E7C7A9-277F-4CCF-90F0-6F722E5F5945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16E7C7A9-277F-4CCF-90F0-6F722E5F5945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16E7C7A9-277F-4CCF-90F0-6F722E5F5945}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E8C3C7F8-6C34-48CF-8969-BB8E6D00F289}
+	EndGlobalSection
+EndGlobal

--- a/blazor/PoprunsBlazorPages/App.razor
+++ b/blazor/PoprunsBlazorPages/App.razor
@@ -1,0 +1,6 @@
+﻿<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/blazor/PoprunsBlazorPages/Layout/MainLayout.razor
+++ b/blazor/PoprunsBlazorPages/Layout/MainLayout.razor
@@ -1,0 +1,8 @@
+﻿@inherits LayoutComponentBase
+<div class="page">
+    <main>
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>

--- a/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/ComboGeneratorPage.razor
+++ b/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/ComboGeneratorPage.razor
@@ -1,0 +1,33 @@
+﻿@page "/pop-2008/combo-generator"
+@using PoprunsBlazorPages.Pop2008.ComboGenerator
+
+<PageTitle>PoP 2008 Combo Generator</PageTitle>
+
+<form @onsubmit="GetCombos">
+	<input
+		type="number"
+		min="@Generator.MinHp"
+		required
+		@bind="_hp"/>
+	<select required @bind="_enemy">
+		<option value="">--Choose enemy--</option>
+		<option>@Enemy.Hunter</option>
+		<option>@Enemy.Concubine</option>
+		<option>@Enemy.Alchemist</option>
+		<option>@Enemy.Dad</option>
+	</select>
+	<input type="checkbox" @bind="_canStartWithB0"/>
+	<input type="submit" value="Compute"/>
+	<br/>
+</form>
+@_combos
+
+@code {
+	private int? _hp;
+	private Enemy? _enemy;
+	private bool _canStartWithB0 = true;
+
+	private string _combos = string.Empty;
+
+	private void GetCombos() => _combos = Generator.GetCombos((int)_hp!, (Enemy)_enemy!, _canStartWithB0);
+}

--- a/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Enemy.cs
+++ b/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Enemy.cs
@@ -1,0 +1,9 @@
+﻿namespace PoprunsBlazorPages.Pop2008.ComboGenerator;
+
+public enum Enemy
+{
+    Hunter,
+    Concubine,
+    Alchemist,
+    Dad
+}

--- a/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Generator.cs
+++ b/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Generator.cs
@@ -1,0 +1,119 @@
+﻿using System.Text;
+
+namespace PoprunsBlazorPages.Pop2008.ComboGenerator;
+
+public static class Generator
+{
+    public const int MinHp = 13;
+
+    public static string GetCombos(int hp, Enemy enemy, bool canStartWithB0 = true)
+    {
+        if (hp % 2 != 0)
+            hp++;
+        if (hp < MinHp)
+            throw new NotSupportedException($"HP must be at least {MinHp}");
+
+        if (hp < 26)
+            return GetCombosSmall(hp);
+
+        int r = hp % 26;
+
+        bool basic =
+            r == 0 ||
+            enemy == Enemy.Hunter ||
+            enemy == Enemy.Concubine ||
+            r > 12 ||
+            canStartWithB0;
+        if (basic)
+            return GetCombosBasic(hp, canStartWithB0);
+
+        if (r == 4 || r == 6 || hp == 28)
+            return Serialize([new("B2", hp / 26 - 1), new("A1**")]);
+        if (r == 8)
+            return Serialize([new("B2", hp / 26 - 1), new("B2*")]);
+        if (r == 2)
+            return Serialize([new("B1"), new("B2", hp / 26 - 2), new("B2*")]);
+
+        // 10 <= r <= 24, hp > 26
+        int comboCount = hp / 26 + 1;
+        int b1Count = (26 * comboCount - hp) / 6; // always 0, 1, or 2
+        int b2Count = comboCount - b1Count;
+        return Serialize([new("B1", b1Count), new("B2", b2Count)]);
+    }
+
+    private static string GetCombosSmall(int hp)
+        => hp switch
+        {
+            <= 20 => Serialize([new("B1")]),
+            <= 26 => Serialize([new("B2")]),
+            _ => throw new Exception("Internal error: small hp must be at most 26")
+        };
+
+    private static string GetCombosBasic(int hp, bool canStartWithB0)
+    {
+        if (hp < 26)
+            return GetCombosSmall(hp);
+        if (hp % 26 == 0)
+            return Serialize([new("B2", hp / 26)]);
+        int comboCount = hp / 26 + 1;
+        int b0Count = (26 * comboCount - hp) / 14; // always 0 or 1
+        int b1Count = (26 * comboCount - 14 * b0Count - hp) / 6; // always 0, 1, or 2 (but at most 1 if b0Count is 1)
+        int b2Count = comboCount - b0Count - b1Count;
+        return canStartWithB0 ?
+            Serialize([new("B0", b0Count), new("B1", b1Count), new("B2", b2Count)]) :
+            Serialize(GetCombosB0Second(new("B0", b0Count), [new("B1", b1Count), new("B2", b2Count)]));
+    }
+
+    private static string Serialize(IEnumerable<MultiCombo> multiComboStream)
+    {
+        MultiCombo[] multiCombos = [..multiComboStream.Where(multiCombo => multiCombo.Count > 0)];
+        StringBuilder builder = new();
+        int buffer = 0;
+        for (int i = 0; i < multiCombos.Length; i++)
+        {
+            (string combo, int count) = multiCombos[i];
+            count += buffer;
+            buffer = 0;
+            if (i < multiCombos.Length - 1 && multiCombos[i + 1].Combo == combo)
+            {
+                buffer = count;
+                continue;
+            }
+            builder.Append(combo);
+            if (count > 1)
+            {
+                builder.Append('^');
+                builder.Append(count);
+            }
+            builder.Append(' ');
+        }
+        while (char.IsWhiteSpace(builder[^1]))
+            builder.Remove(builder.Length - 1, 1);
+        return builder.ToString();
+    }
+
+    private static IEnumerable<MultiCombo> GetCombosB0Second(MultiCombo b0MultiCombo, IEnumerable<MultiCombo> otherMultiCombos)
+    {
+        bool b0MultiComboAdded = false;
+        foreach (MultiCombo multiCombo in otherMultiCombos)
+        {
+            if (b0MultiComboAdded)
+            {
+                yield return multiCombo;
+                continue;
+            }
+            if (multiCombo.Count < 1)
+            {
+                yield return multiCombo;
+                continue;
+            }
+            yield return new(multiCombo.Combo, 1);
+            yield return b0MultiCombo;
+            yield return new(multiCombo.Combo, multiCombo.Count - 1);
+            b0MultiComboAdded = true;
+        }
+        if (b0MultiComboAdded)
+            yield break;
+        yield return b0MultiCombo;
+    }
+}

--- a/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/MultiCombo.cs
+++ b/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/MultiCombo.cs
@@ -1,0 +1,3 @@
+﻿namespace PoprunsBlazorPages.Pop2008.ComboGenerator;
+
+public readonly record struct MultiCombo(string Combo, int Count = 1);

--- a/blazor/PoprunsBlazorPages/PoprunsBlazorPages.csproj
+++ b/blazor/PoprunsBlazorPages/PoprunsBlazorPages.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/blazor/PoprunsBlazorPages/Program.cs
+++ b/blazor/PoprunsBlazorPages/Program.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+namespace PoprunsBlazorPages;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+        builder.RootComponents.Add<App>("#app");
+        builder.RootComponents.Add<HeadOutlet>("head::after");
+
+        builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+        await builder.Build().RunAsync();
+    }
+}

--- a/blazor/PoprunsBlazorPages/Properties/launchSettings.json
+++ b/blazor/PoprunsBlazorPages/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "http://localhost:5036",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:7073;http://localhost:5036",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/blazor/PoprunsBlazorPages/_Imports.razor
+++ b/blazor/PoprunsBlazorPages/_Imports.razor
@@ -1,0 +1,10 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using PoprunsBlazorPages
+@using PoprunsBlazorPages.Layout

--- a/blazor/PoprunsBlazorPages/wwwroot/index.html
+++ b/blazor/PoprunsBlazorPages/wwwroot/index.html
@@ -1,0 +1,18 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PoPRuns - Prince of Persia Speedruns</title>
+    <base href="/" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="PoprunsBlazorPages.styles.css" />
+</head>
+
+<body>
+    <div id="app"></div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
See what this looks like in practice at https://saulm314.github.io/ (the newly added page is https://saulm314.github.io/pop-2008/combo-generator - it has no styling at the moment but it's just a proof of concept; we can apply styling afterwards and also test the new deployment workflow while we're at it). This is a direct copy of this repository after this pull request gets approved, and I've uploaded it just so we can see what the final product looks like without having to approve it. I will delete it as soon as this pull request is approved.

All existing files are unmodified.

On the root directory, the only changes are:
- `blazor`
  - this is the folder containing everything Blazor related, completely separate from the existing raw JavaScript pages
- `404.html`
  - this is the binding file between standard JavaScript pages and Blazor pages; that is, if no standard JavaScript under a URL is found, then this file will be checked, will which will in turn launch the Blazor Web Assembly app and check if the URL matches any pages there (or show a "not found" screen otherwise)
- `.github`
  - this folder contains the workflow needed required to have both types of architecture on the same repository
 
The deployment workflow is as follows:
- when a commit is pushed to the `main` branch, a new deployment automatically begins:
- download .NET SDK 9
- publish (build/compile) the Blazor app
- remove the `index.html` file produced by said compilation, as it is only used for local testing - for the site the only HTML file that the Blazor app will use is `404.html`
- move the `_framework` folder (containing a compiled version of .NET) to the root repository (this is mandatory and there is no way to avoid it)
- move some other required libraries from the Blazor compilation to a new folder on the root repository: `__blazor`
- (therefore if in the future we create a new folder on the root repository, it must not be called `_framework` or `__blazor` so as to not interfere with this workflow)
- delete the entire `blazor` folder, as everything we needed from it has already been moved out, so we free up some space to avoid having to upload a very heavy page
- upload everything that's left on the root directory as a GitHub Page

**TO DO**
In order for this new workflow to be supported, the following settings have to be applied on the repository:
- Under Actions/General/Actions permissions, check "Allow all actions and reusable workflows"
- Under Pages/Build and deployment/Source, select GitHub Actions

Ideally these settings should be applied before the pull request is merged, but if they're not and the deployment fails, we can always trivially redeploy manually once the correct settings are applied.