### PR TITLE
Fix empty combo serialization and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # https://popruns.github.io/
 # Build
-To build and test the site locally, open the root directory in a terminal and run `python3 build.py`. Requires Python 3+ and .NET SDK 9+.
+To build and test the site locally, open the root directory in a terminal and run `python3 build.py`, then open http://127.0.0.1:8080 in a browser. Hit `Ctrl+C` in the terminal to stop testing. Requires Python 3+ and .NET SDK 9+.
 
-To test just the raw HTML/CSS/JS pages locally, open the root directory in a terminal and run `python3 -m http.server`. Requires Python 3+.
+To test just the raw HTML/CSS/JS pages locally (no Blazor), open the root directory in a terminal and run `python3 -m http.server`, then open http://127.0.0.1:8000 in a browser. Hit `Ctrl+C` in the terminal to stop testing. Requires Python 3+.
+
+## For Novices
+Before testing the site locally, first you need to clone/download the repository, and then open the repository's root directory in a terminal. E.g. in Windows you can do this by navigating to the root directory in file explorer, then right-clicking on any empty space, and pressing "Open in Terminal". Alternatively (in any operating system), open the "Terminal" app, then type `cd path/to/repository` and replace `path/to/repository` with the path for where you cloned/downloaded the repository, e.g. `cd C:\Users\JohnSmith\Documents\github\popruns.github.io`.

--- a/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Generator.cs
+++ b/blazor/PoprunsBlazorPages/Pages/pop-2008/combo-generator/Generator.cs
@@ -87,7 +87,7 @@ public static class Generator
             }
             builder.Append(' ');
         }
-        while (char.IsWhiteSpace(builder[^1]))
+        while (builder.Length > 0 && char.IsWhiteSpace(builder[^1]))
             builder.Remove(builder.Length - 1, 1);
         return builder.ToString();
     }


### PR DESCRIPTION
Two minor changes:
### 1. Fix empty combo serialization:
Technically this did not make any difference in the current state of the combo generator, but if the serializer for combo generation did ever receive an empty combo (e.g. `B0^0 B1^0 B2^0`) it would have thrown an error, instead of just returning an empty string. Yes, currently, the serializer should never get that combo in the first place, but it should not have such a dependency and should be completely separate from the rest of the combo generator, as its sole job is to serialize combos (any combos).
### 2. Update README.md
The build instructions have been made a bit more precise, and added a "For Novices" section. In practice, anyone who already knows how to clone a repository and open a terminal to its root directory will not need these instructions in the first place. They will just see a `build.py` file and try running it.

I personally highly dislike it when instructions are made only for people who already know how to carry out the task, because then they are almost pointless. It happens quite often for me that I will follow such instructions and not know how to carry out the steps that the author assumes everyone knows, only to spend 30 minutes (or much longer) figuring them out, and then wonder why the author couldn't have just included those steps in the instructions in the first place.

A counter-argument may be that someone who doesn't even know how to navigate a terminal is unlikely to contribute in the first place, but this is not true, as such a person could easily make a contribution such as #8, but they will want to build locally to confirm their change works. Moreover, a person can easily be familiar with Python/C#/JavaScript/HTML/CSS/etc. without ever having learnt how to navigate a terminal. Most normie Python users probably can't navigate a terminal. But such a normie Python user could still contribute to any Python scripts. Finally, even if such a person will not contribute, they may at the very least learn something which could be valuable for them.

Another counter-argument could be that hand-holding a novice may impede on the regular developer's ability to read through the instructions quickly, but this is not true because the novice instructions are in their own section which the regular developer can skip reading entirely.

So my belief is that - since this is a public project - anyone should be able to understand the instructions and contribute, even if they are not a software developer (though basic computing skills are assumed). I know that such basic considerations would have made me from 5 years ago (who indeed did not know how to navigate a terminal) much more likely to contribute. And if you look back, I was indeed contributing to autosplitters and whatnot despite not knowing very basic things. I wrote the original `multipop` autosplitter despite not knowing what a terminal is and having zero knowledge of C#. I also wrote the original code that collected the 2k8 beam data and stored it in a file, also without knowing what a terminal is. So it should not be assumed that a person with limited knowledge will not contribute.